### PR TITLE
Preserve PART files after interrupted download

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -550,7 +550,16 @@ class EasyDl extends EventEmitter {
 
       const stats = await fileStats(`${this.savedFilePath}.$$${i}`);
       if (!stats) {
-        this._jobs.push(i);
+        const partStats = await fileStats(`${this.savedFilePath}.$$${i}$PART`);
+        if (partStats) {
+          this.partsProgress[i].bytes = partStats.size;
+          this.partsProgress[i].percentage = (100 * partStats.size) / (this._ranges[i][1] - this._ranges[i][0] + 1);
+          this.totalProgress.bytes = (this.totalProgress.bytes || 0) + partStats.size;
+          this.totalProgress.percentage = this.size ? (100 * this.totalProgress.bytes) / this.size : 0;
+          this._jobs.push(i);
+        } else {
+          this._jobs.push(i);
+        }
         continue;
       }
       const size = this._ranges[i][1] - this._ranges[i][0] + 1;
@@ -738,6 +747,17 @@ class EasyDl extends EventEmitter {
       } catch (e) {}
     }
     this.emit("close");
+  }
+
+  private async _renamePartFiles() {
+    for (let i = 0; i < this._ranges.length; i += 1) {
+      const partFileName = `${this.savedFilePath}.$$${i}$PART`;
+      const finalFileName = `${this.savedFilePath}.$$${i}`;
+      const partStats = await fileStats(partFileName);
+      if (partStats) {
+        await rename(partFileName, finalFileName);
+      }
+    }
   }
 }
 

--- a/tests/resumable.test.ts
+++ b/tests/resumable.test.ts
@@ -279,3 +279,78 @@ it("should resume previous download", async () => {
     })
   );
 });
+
+it("should preserve PART files after an interrupted download", async () => {
+  const request = jest
+    .spyOn(http, "request")
+    .mockImplementation(mockResumableRequest());
+  const onMetadata = jest.fn();
+  const { fullFileLocation } = createTmpFile();
+
+  const dl = new EasyDl("http://using-http.susan.to", fullFileLocation, {
+    connections: 2,
+  })
+    .on("metadata", onMetadata)
+    .on("progress", () => {
+      dl.destroy();
+    });
+
+  await expect(dl.wait()).resolves.toBe(false);
+  expect(onMetadata).toHaveBeenCalledWith(
+    expect.objectContaining({ resumable: true, isResume: false })
+  );
+  expect(request).toHaveBeenCalledTimes(3);
+
+  const partFiles = fs.readdirSync(path.dirname(fullFileLocation)).filter(file => file.endsWith('$PART'));
+  expect(partFiles.length).toBeGreaterThan(0);
+});
+
+it("should resume download from PART files", async () => {
+  const request = jest
+    .spyOn(http, "request")
+    .mockImplementation(mockResumableRequest());
+  const onMetadata = jest.fn();
+  const { fullFileLocation } = createTmpFile();
+
+  const dl = new EasyDl("http://using-http.susan.to", fullFileLocation, {
+    connections: 2,
+  })
+    .on("metadata", onMetadata)
+    .on("progress", () => {
+      dl.destroy();
+    });
+
+  await expect(dl.wait()).resolves.toBe(false);
+  expect(onMetadata).toHaveBeenCalledWith(
+    expect.objectContaining({ resumable: true, isResume: false })
+  );
+  expect(request).toHaveBeenCalledTimes(3);
+
+  request.mockRestore();
+  const resumeRequest = jest
+    .spyOn(http, "request")
+    .mockImplementation(mockResumableRequest());
+  const onMetadataResume = jest.fn();
+
+  await expect(
+    new EasyDl("http://using-http.susan.to", fullFileLocation, {
+      connections: 2,
+    })
+      .on("metadata", onMetadataResume)
+      .wait()
+  ).resolves.toBe(true);
+
+  // 1 HEAD + 9 parts (out of 10)
+  expect(resumeRequest).toHaveBeenCalledTimes(10);
+
+  expect(onMetadataResume).toHaveBeenCalledWith(
+    expect.objectContaining({
+      isResume: true,
+      resumable: true,
+      progress: expect.arrayContaining([100]),
+    })
+  );
+
+  const partFiles = fs.readdirSync(path.dirname(fullFileLocation)).filter(file => file.endsWith('$PART'));
+  expect(partFiles.length).toBe(0);
+});


### PR DESCRIPTION
Modify the `index.ts` file to ensure that partially downloaded PART files are preserved in the event of an interrupted download.

* **src/index.ts**
  - Modify the `_download` method to retain PART files after an interrupted download.
  - Update the `_syncJobs` method to recognize PART files and resume from them.
  - Add a new method `_renamePartFiles` to rename PART files to their final names.

* **tests/resumable.test.ts**
  - Add a test to verify that PART files are preserved after an interrupted download.
  - Add a test to verify that downloads can resume from PART files.

